### PR TITLE
Update button styles for light mode

### DIFF
--- a/SkinLiberty.php
+++ b/SkinLiberty.php
@@ -244,10 +244,10 @@ class SkinLiberty extends SkinTemplate {
 			}
 		}
 
-		$LibertyDarkCss = "body, .Liberty, .dropdown-menu, .dropdown-item, .Liberty .nav-wrapper .navbar .form-inline .btn, .Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link.active, .Liberty .content-wrapper .liberty-content .liberty-content-main table.wikitable tr > th, .Liberty .content-wrapper .liberty-content .liberty-content-main table.wikitable tr > td, table.mw_metadata th, .Liberty .content-wrapper .liberty-content .liberty-content-main table.infobox th, #preferences fieldset:not(.prefsection), #preferences div.mw-prefs-buttons, .navbox, .navbox-subgroup, .navbox > tbody > tr:nth-child(even) > .navbox-list {
-			background-color: #000;
-			color: #DDD;
-		}
+                $LibertyDarkCss = "body, .Liberty, .dropdown-menu, .dropdown-item, .Liberty .nav-wrapper .navbar .form-inline .btn, .Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link.active, .Liberty .content-wrapper .liberty-content .liberty-content-main table.wikitable tr > th, .Liberty .content-wrapper .liberty-content .liberty-content-main table.wikitable tr > td, table.mw_metadata th, .Liberty .content-wrapper .liberty-content .liberty-content-main table.infobox th, #preferences fieldset:not(.prefsection), #preferences div.mw-prefs-buttons, .navbox, .navbox-subgroup, .navbox > tbody > tr:nth-child(even) > .navbox-list {
+                        background-color: #000;
+                        color: #DDD;
+                }
 
 		.liberty-content-header, .liberty-footer, .Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-footer, .Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item, .Liberty .content-wrapper .liberty-content .liberty-content-header, .Liberty .content-wrapper .liberty-footer, .editOptions, html .wikiEditor-ui-toolbar, #pagehistory li.selected, .mw-datatable td, .Liberty .content-wrapper .liberty-content .liberty-content-main table.wikitable tr > td, table.mw_metadata td, .Liberty .content-wrapper .liberty-content .liberty-content-main table.wikitable, .Liberty .content-wrapper .liberty-content .liberty-content-main table.infobox, #preferences, .navbox-list, .dropdown-divider {
 			background-color: #1F2023;
@@ -270,14 +270,27 @@ class SkinLiberty extends SkinTemplate {
 		.flow-topic-titlebar { color: #000; }
 		.flow-ui-navigationWidget { color: #FFF; }
 		.Liberty .content-wrapper .liberty-content .liberty-content-main .toccolours, .Liberty .content-wrapper .liberty-content .liberty-content-main .toc ul, .Liberty .content-wrapper .liberty-content .liberty-content-main .toc li { background-color: #000; }
-		.Liberty .content-wrapper .liberty-content .liberty-content-main .toc .toctitle { background-color: #1F2023; }";
+                .Liberty .content-wrapper .liberty-content .liberty-content-main .toc .toctitle { background-color: #1F2023; }";
 
-		$LibertyUserDarkSetting = $userOptionsLookup->getOption( $user, 'liberty-dark' );
-		if ( $LibertyUserDarkSetting === 'dark' ) {
-			$out->addInlineStyle( $LibertyDarkCss );
-		} elseif ( $LibertyUserDarkSetting === null ) {
-			$out->addInlineStyle( "@media (prefers-color-scheme: dark) { $LibertyDarkCss }" );
-		}
+                $LibertyLightCss = "#searchGoButton, #mw-searchButton, .btn-group .btn {
+                        background-color: #fff;
+                        border-color: $mainColor;
+                }
+
+                .btn-group .btn:hover,
+                .btn-group a:hover {
+                        text-decoration: none;
+                }";
+
+                $LibertyUserDarkSetting = $userOptionsLookup->getOption( $user, 'liberty-dark' );
+                if ( $LibertyUserDarkSetting === 'dark' ) {
+                        $out->addInlineStyle( $LibertyDarkCss );
+                } elseif ( $LibertyUserDarkSetting === 'light' ) {
+                        $out->addInlineStyle( $LibertyLightCss );
+                } elseif ( $LibertyUserDarkSetting === null ) {
+                        $out->addInlineStyle( "@media (prefers-color-scheme: dark) { $LibertyDarkCss }" );
+                        $out->addInlineStyle( "@media (prefers-color-scheme: light) { $LibertyLightCss }" );
+                }
 
 		// @codingStandardsIgnoreEnd
 		$this->setupCss( $out );

--- a/css/default.css
+++ b/css/default.css
@@ -116,8 +116,15 @@ a {
     text-decoration: none; /* No underline by default */
 }
 
+
 a:hover {
     text-decoration: underline; /* Underline on hover */
+}
+
+/* Use the secondary button background as the text color inside .btn-group */
+.btn-group .btn,
+.btn-group a {
+    color: var(--bs-btn-bg, #6c757d);
 }
 
 .btn-group .btn:hover,

--- a/css/default.css
+++ b/css/default.css
@@ -120,6 +120,11 @@ a:hover {
     text-decoration: underline; /* Underline on hover */
 }
 
+.btn-group .btn:hover,
+.btn-group a:hover {
+    text-decoration: none;
+}
+
 ul {
 	list-style-image: url(data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22%3F%3E%0A%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20width%3D%225%22%20height%3D%2213%22%3E%0A%3Ccircle%20cx%3D%222.5%22%20cy%3D%229.5%22%20r%3D%222.5%22%20fill%3D%22%23373a3c%22%2F%3E%0A%3C%2Fsvg%3E%0A);
 }


### PR DESCRIPTION
## Summary
- add light mode styles for search and tools buttons
- prevent underline on buttons inside `.btn-group`

## Testing
- `npm test`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400190051c8329bc8093c680376aec