### PR TITLE
Add responsive footnote tooltip and modal

### DIFF
--- a/css/custom-modals.css
+++ b/css/custom-modals.css
@@ -1,1 +1,22 @@
 /* css/custom-modals.css - For footnote modal and other custom modal styling */
+
+.liberty-footnote-modal[data-bs-theme='dark'] .modal-content {
+    background-color: #000;
+    color: #ddd;
+}
+
+.liberty-footnote-modal[data-bs-theme='light'] .modal-content {
+    background-color: #fff;
+    color: #000;
+}
+
+.tooltip[data-bs-theme='dark'] {
+    --bs-tooltip-bg: #333;
+    --bs-tooltip-color: #fff;
+}
+
+.tooltip[data-bs-theme='light'] {
+    --bs-tooltip-bg: #fff;
+    --bs-tooltip-color: #000;
+    border: 1px solid #ccc;
+}


### PR DESCRIPTION
## Summary
- implement tooltip on desktop and modal on mobile for footnotes
- set Bootstrap theme for dark/light mode
- style footnote tooltip and modal to support themes

## Testing
- `npm test`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497449afe083299885ca6c8ccf060e