### PR TITLE
Add footer width synchronization script

### DIFF
--- a/js/footer-width-sync.js
+++ b/js/footer-width-sync.js
@@ -1,0 +1,21 @@
+(function () {
+    'use strict';
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var content = document.getElementById('content');
+        var footer = document.querySelector('body > section > div > div > footer');
+
+        function updateWidth() {
+            if (!content || !footer) {
+                return;
+            }
+            var width = content.offsetWidth;
+            footer.style.width = width + 'px';
+            console.log('content width:', width, 'footer width:', footer.offsetWidth);
+        }
+
+        updateWidth();
+        window.addEventListener('resize', updateWidth);
+        setInterval(updateWidth, 500);
+    });
+})();

--- a/skin.json
+++ b/skin.json
@@ -132,7 +132,8 @@
 				"js/layout.js",
 				"js/table.js",
 				"js/scroll-button.js",
-				"js/references-tooltip.js"
+                                "js/references-tooltip.js",
+                                "js/footer-width-sync.js"
 			],
 			"dependencies": "mediawiki.cookie"
 		},


### PR DESCRIPTION
## Summary
- sync footer width to `#content` width automatically
- load the new script in the Liberty skin

## Testing
- `composer test` *(fails: Array and string offset access syntax with curly braces is no longer supported)*
- `npx eslint js --ignore-pattern 'lib/'` *(fails: Parsing error: The keyword 'const' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_684a05b7d3648329ac2aac19532466bc